### PR TITLE
Add master selection option to StateManager

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,12 +7,14 @@ from statemanager import StateManager
 def main():
     parser = argparse.ArgumentParser(description="ArmonixNG - MIDI System Control")
     parser.add_argument('--verbose', action='store_true', help='Abilita il logging dettagliato')
+    parser.add_argument('--master', choices=['fantom', 'launchkey'], default='fantom',
+                        help='Seleziona la tastiera master')
     args = parser.parse_args()
 
     app = QtWidgets.QApplication(sys.argv)
 
     # Lo StateManager gestisce tutto lo stato, i led, e il logging
-    state_manager = StateManager(verbose=args.verbose)
+    state_manager = StateManager(master=args.master, verbose=args.verbose)
     led_bar = LedBar(states_getter=state_manager.get_led_states)
     state_manager.set_ledbar(led_bar)
     led_bar.set_state_manager(state_manager)

--- a/statemanager.py
+++ b/statemanager.py
@@ -5,8 +5,9 @@ from fantom_midi_filter import filter_and_translate_fantom_msg
 from PyQt5 import QtCore
 
 class StateManager(QtCore.QObject):
-    def __init__(self, verbose=False):
+    def __init__(self, master='fantom', verbose=False):
         super().__init__()
+        self.master = master
         self.verbose = verbose
         self.ledbar = None
         self.fantom_port = None


### PR DESCRIPTION
## Summary
- add `--master` option to choose between 'fantom' or 'launchkey'
- pass selected master keyboard to `StateManager`
- update `StateManager` to store the chosen master

## Testing
- `python -m py_compile main.py statemanager.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'PyQt5')*
- `apt-get update` *(fails: 403 Forbidden for Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68959f05c7d883239822112cc9471588