### PR TITLE
Add Launchkey MIDI filter with configurable mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Sono inclusi due script di utilità:
 
 Il file `keypad_config.json` definisce la mappatura tra i tasti del tastierino e i messaggi Sysex o Footswitch da inviare al Ketron. È possibile modificare questo file per adattare i comandi alle proprie esigenze.
 
+## Configurazione della Launchkey
+
+Il file `launchkey_config.json` permette di associare i messaggi MIDI generati dalla Novation Launchkey ai comandi del Ketron. La struttura è la seguente:
+
+```
+{
+  "footswitch": {"<nota>": "<nome FOOTSWITCH>"},
+  "tabs": {"<nota>": "<nome TABS>"},
+  "program_change": {"MSB,LSB,PC": <azione>}
+}
+```
+
+Le stringhe devono corrispondere ai simboli definiti in `footswitch_lookup.py` e `tabs_lookup.py`. Le triple `MSB,LSB,PC` identificano un Program Change che il filtro MIDI può tradurre in un'azione specifica.
+
 ## Adattamenti ad altri setup
 
 La logica è suddivisa in moduli (gestione dello stato, filtro MIDI, listener per il tastierino), rendendo relativamente semplice l'estensione a strumenti o controller diversi. Basterà modificare le mappature e, se necessario, aggiungere nuovi filtri MIDI.

--- a/launchkey_config.json
+++ b/launchkey_config.json
@@ -1,0 +1,12 @@
+{
+  "footswitch": {
+    "60": "ARR.A",
+    "61": "BREAK"
+  },
+  "tabs": {
+    "62": "HOLD"
+  },
+  "program_change": {
+    "105,0,127": 1
+  }
+}

--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import json
+
+from footswitch_lookup import FOOTSWITCH_LOOKUP
+from tabs_lookup import TABS_LOOKUP
+from sysex_utils import send_sysex_to_ketron, sysex_footswitch_std, sysex_tabs
+import mido
+
+"""
+launchkey_config.json structure::
+{
+  "footswitch": {"<note>": "<FOOTSWITCH_NAME>"},
+  "tabs": {"<note>": "<TABS_NAME>"},
+  "program_change": {"MSB,LSB,PC": <action_number>}
+}
+- <note> is the MIDI note number sent by the Launchkey.
+- Names must exist in footswitch_lookup.py or tabs_lookup.py.
+- Program-change triples map to an arbitrary action number handled by
+  ``key_pressed``.
+"""
+
+CONFIG = json.load(open(Path(__file__).with_name('launchkey_config.json')))
+
+_last_msb = None
+_last_lsb = None
+
+def filter_and_translate_launchkey_msg(msg, ketron_outport, state_manager=None, armonix_enabled=True, verbose=False):
+    global _last_msb, _last_lsb
+
+    if msg.type == "note_on" and armonix_enabled:
+        note_key = str(msg.note)
+        if note_key in CONFIG.get("footswitch", {}):
+            name = CONFIG["footswitch"][note_key]
+            status = 0x7F if msg.velocity else 0x00
+            data = sysex_footswitch_std(FOOTSWITCH_LOOKUP[name], status)
+            send_sysex_to_ketron(ketron_outport, data)
+            if verbose:
+                print(f"[LAUNCHKEY-FILTER] Footswitch {name} note={msg.note}")
+            return
+        if note_key in CONFIG.get("tabs", {}):
+            name = CONFIG["tabs"][note_key]
+            status = 0x7F if msg.velocity else 0x00
+            data = sysex_tabs(TABS_LOOKUP[name], status)
+            send_sysex_to_ketron(ketron_outport, data)
+            if verbose:
+                print(f"[LAUNCHKEY-FILTER] Tab {name} note={msg.note}")
+            return
+
+    elif msg.type == "control_change" and armonix_enabled:
+        if msg.control == 0:
+            _last_msb = msg.value
+            if verbose:
+                print(f"[LAUNCHKEY-FILTER] Salvato MSB: {_last_msb}")
+            return
+        if msg.control == 32:
+            _last_lsb = msg.value
+            if verbose:
+                print(f"[LAUNCHKEY-FILTER] Salvato LSB: {_last_lsb}")
+            return
+
+    elif msg.type == "program_change" and armonix_enabled:
+        msb = _last_msb if _last_msb is not None else 0
+        lsb = _last_lsb if _last_lsb is not None else 0
+        key = f"{msb},{lsb},{msg.program}"
+        action = CONFIG.get("program_change", {}).get(key)
+        if action:
+            key_pressed(action, ketron_outport.name, verbose)
+            if verbose:
+                print(f"[LAUNCHKEY-FILTER] Program Change {key} -> {action}")
+            return
+
+    ketron_outport.send(msg)
+    if verbose:
+        print(f"[LAUNCHKEY-FILTER] msg inalterato: {msg}")
+
+def key_pressed(val, ketron_port_name, verbose):
+    if verbose:
+        print(f"[LAUNCHKEY-FILTER] key_pressed chiamato con {val} -- azione da implementare")


### PR DESCRIPTION
## Summary
- add `launchkey_config.json` defining footswitch, tab, and program-change mappings
- introduce `launchkey_midi_filter.py` that loads the configuration and translates Launchkey events
- document `launchkey_config.json` format in README for easier customization

## Testing
- `python -m json.tool launchkey_config.json`
- `python -m py_compile launchkey_midi_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_6895a01076308323a9d077db978a64e0