### PR TITLE
Document master option and Launchkey setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,29 @@ Sono inclusi due script di utilità:
 - `start_immortal.sh` esegue `main.py` in loop e riavvia automaticamente il programma in caso di uscita.
 - `start-touchdesk.sh` prova a collegarsi via VNC al Ketron EVM quando viene rilevata la rete corretta.
 
+### Opzione `--master`
+
+Il programma accetta l'opzione `--master` per selezionare quale tastiera agisce da controller principale.
+Le scelte disponibili sono `fantom` e `launchkey`; il valore predefinito è `fantom`.
+Esempio d'uso:
+
+```bash
+python main.py --master launchkey
+```
+
 ## Configurazione del tastierino
 
 Il file `keypad_config.json` definisce la mappatura tra i tasti del tastierino e i messaggi Sysex o Footswitch da inviare al Ketron. È possibile modificare questo file per adattare i comandi alle proprie esigenze.
+
+## Modulo Launchkey
+
+Per utilizzare un controller Novation Launchkey come master, definire le mappature nel file `launchkey_config.json`.
+Il file contiene l'associazione tra pad/manopole del Launchkey e i comandi da inviare al Ketron.
+Una volta configurato, avviare il programma con:
+
+```bash
+python main.py --master launchkey
+```
 
 ## Adattamenti ad altri setup
 

--- a/launchkey_config.json
+++ b/launchkey_config.json
@@ -1,0 +1,4 @@
+{
+  "PAD1": { "type": "FOOTSWITCH", "name": "START/STOP" },
+  "PAD2": { "type": "FOOTSWITCH", "name": "TEMPO UP" }
+}


### PR DESCRIPTION
## Summary
- explain new `--master` option with `fantom` and `launchkey` choices
- add Launchkey module setup instructions and sample `launchkey_config.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6895a0143a64832387bb8aab0ad7959f