### PR TITLE
Add Launchkey DAW port listener and initialization

### DIFF
--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -8,3 +8,9 @@ def filter_and_translate_launchkey_msg(msg, ketron_outport, state_manager, armon
             print(f"[LAUNCHKEY-FILTER] Inviato inalterato: {msg}")
     elif verbose:
         print(f"[LAUNCHKEY-FILTER] Bloccato: {msg}")
+
+
+def filter_and_translate_launchkey_daw_msg(msg, daw_outport, state_manager, verbose=False):
+    """Filtro dedicato per la porta DAW del Launchkey."""
+    if verbose:
+        print(f"[LAUNCHKEY-DAW-FILTER] Ricevuto: {msg}")


### PR DESCRIPTION
## Summary
- detect Launchkey MK3 88 DAW in/out ports and manage their connection state
- send initialization note_on messages and handle DAW traffic in dedicated thread
- introduce DAW-specific MIDI filter

## Testing
- `python -m py_compile launchkey_midi_filter.py statemanager.py`

------
https://chatgpt.com/codex/tasks/task_e_68961e363b208323a5b000ad419184d5