### PR TITLE
Filtra messaggi Launchkey non su canale 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Sono inclusi due script di utilità:
 - `start_immortal.sh` esegue `main.py` in loop e riavvia automaticamente il programma in caso di uscita.
 - `start-touchdesk.sh` prova a collegarsi via VNC al Ketron EVM quando viene rilevata la rete corretta.
 
+## Test manuali
+
+Per verificare il corretto filtraggio dei messaggi della Launchkey, è disponibile
+uno script di test manuale:
+
+```bash
+python tests/manual_launchkey_filter.py
+```
+
+Questo script conferma che solo i messaggi sul canale 1 (canale 0 per mido)
+vengono inoltrati al Ketron, mentre gli altri vengono scartati.
+
 ## Configurazione del tastierino
 
 Il file `keypad_config.json` definisce la mappatura tra i tasti del tastierino e i messaggi Sysex o Footswitch da inviare al Ketron. È possibile modificare questo file per adattare i comandi alle proprie esigenze.

--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -57,7 +57,20 @@ LAUNCHKEY_FILTERS = _load_launchkey_filters(_config_path)
 
 # --- Master port filter ---------------------------------------------------
 
-def filter_and_translate_launchkey_msg(msg, ketron_outport, state_manager, armonix_enabled=True, state="ready", verbose=False):
+def filter_and_translate_launchkey_msg(
+    msg, ketron_outport, state_manager, armonix_enabled=True, state="ready", verbose=False
+):
+    """
+    Forward Launchkey messages to the Ketron only when they are on MIDI channel 1
+    (mido channel 0). Messages on other channels are ignored, optionally logging
+    the event when ``verbose`` is enabled.
+    """
+
+    if msg.channel != 0:
+        if verbose:
+            print(f"[LAUNCHKEY-FILTER] Ignorato canale {msg.channel}: {msg}")
+        return
+
     if armonix_enabled:
         ketron_outport.send(msg)
         if verbose:

--- a/tests/manual_launchkey_filter.py
+++ b/tests/manual_launchkey_filter.py
@@ -1,0 +1,69 @@
+"""Manual tests for `filter_and_translate_launchkey_msg`.
+
+Run this file directly to verify that only messages on channel 1 (mido
+channel 0) are forwarded to the Ketron output port.
+
+La libreria `mido` non è necessaria per questo test: viene utilizzata una
+semplice classe `FakeMessage` con il solo attributo `channel`.
+"""
+
+import os
+import sys
+import types
+
+# Creazione di un modulo "mido" fittizio per evitare dipendenze esterne.
+mido_stub = types.ModuleType("mido")
+
+def _dummy_open_output(*args, **kwargs):
+    class _DummyPort:
+        name = "dummy"
+
+        def send(self, msg):
+            pass
+
+    return _DummyPort()
+
+mido_stub.open_output = _dummy_open_output
+sys.modules["mido"] = mido_stub
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from launchkey_midi_filter import filter_and_translate_launchkey_msg
+
+
+class DummyPort:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, msg):
+        self.sent.append(msg)
+        print(f"SENT TO KETRON: {msg}")
+
+
+class FakeMessage:
+    """Minimal replacement for mido.Message used in manual tests."""
+
+    def __init__(self, channel):
+        self.channel = channel
+
+    def __repr__(self):
+        return f"FakeMessage(channel={self.channel})"
+
+
+def run():
+    port = DummyPort()
+
+    print("-- Sending channel 0 (should pass) --")
+    msg0 = FakeMessage(channel=0)
+    filter_and_translate_launchkey_msg(msg0, port, None, verbose=True)
+
+    print("-- Sending channel 1 (should be ignored) --")
+    msg1 = FakeMessage(channel=1)
+    filter_and_translate_launchkey_msg(msg1, port, None, verbose=True)
+
+    assert port.sent == [msg0], "Channel filtering failed"
+
+
+if __name__ == "__main__":
+    run()
+


### PR DESCRIPTION
## Summary
- limita il filtro della Launchkey al solo canale 1 (0 in mido) loggando gli altri canali
- aggiunge uno script di test manuale e documentazione per verificare il filtraggio

## Testing
- `python tests/manual_launchkey_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68964170491c83238c803837891ecaee