### PR TITLE
Add selector group support for Launchkey

### DIFF
--- a/launchkey_config.json
+++ b/launchkey_config.json
@@ -13,18 +13,22 @@
 // ritmi: verde (giallo se pericoloso)
 // mic: rosso
 {
+  "SELECTOR_GROUPS": [
+    { "group_id": 1, "on_color": 20, "off_color": 13 },
+    { "group_id": 2, "on_color": 40, "off_color": 0 }
+  ],
   "NOTE": [
-    { "note":  96,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 1", "color": 40, "colormode": "static" },
-    { "note":  97,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 2", "color": 41, "colormode": "static" },
-    { "note":  98,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 3", "color": 42, "colormode": "static" },
-    { "note":  99,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 4", "color": 43, "colormode": "static" },
+    { "note":  96,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 1", "group": 2, "color": 0, "colormode": "static" },
+    { "note":  97,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 2", "group": 2, "color": 0, "colormode": "static" },
+    { "note":  98,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 3", "group": 2, "color": 0, "colormode": "static" },
+    { "note":  99,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 4", "group": 2, "color": 0, "colormode": "static" },
     { "note": 100,  "channel": 0,  "type": "TABS", "name": "PIANIST", "color": 46, "colormode": "static" },
     { "note": 102,  "channel": 0,  "type": "FOOTSWITCH", "name": "MICRO1 ON/OFF", "color": 5, "colormode": "static" },
     { "note": 103,  "channel": 0,  "type": "FOOTSWITCH", "name": "VOICETR.ON/OFF", "color": 69, "colormode": "static" },
-    { "note": 112,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.A", "color": 20, "colormode": "static" },
-    { "note": 113,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.B", "color": 20, "colormode": "static" },
-    { "note": 114,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.C", "color": 20, "colormode": "static" },
-    { "note": 115,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.D", "color": 20, "colormode": "static" },
+    { "note": 112,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.A", "group": 1, "color": 13, "colormode": "static" },
+    { "note": 113,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.B", "group": 1, "color": 13, "colormode": "static" },
+    { "note": 114,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.C", "group": 1, "color": 13, "colormode": "static" },
+    { "note": 115,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.D", "group": 1, "color": 13, "colormode": "static" },
     { "note": 116,  "channel": 0,  "type": "FOOTSWITCH", "name": "BREAK", "color": 65, "colormode": "static" },
     { "note": 117,  "channel": 0,  "type": "FOOTSWITCH", "name": "FILL", "color": 75, "colormode": "static" },
     { "note": 118,  "channel": 0,  "type": "FOOTSWITCH", "name": "VARI", "color": 100, "colormode": "static" },

--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -21,8 +21,16 @@ _config_path = os.path.join(base_dir, "launchkey_config.json")
 
 
 def _load_launchkey_filters(path):
-    """Load launchkey_config.json stripping comments."""
+    """Load launchkey_config.json stripping comments.
+
+    Besides the regular NOTE/CC mappings this loader also initializes
+    ``LAUNCHKEY_GROUPS`` which describes selector groups.  Each group is a
+    dictionary with ``on_color`` and ``off_color`` along with the list of
+    member controls.
+    """
+
     filters = {"NOTE": {}, "CC": {}}
+    groups = {}
     try:
         with open(path, "r") as f:
             lines = f.readlines()
@@ -35,12 +43,27 @@ def _load_launchkey_filters(path):
     except Exception:
         data = {}
 
+    for grp in data.get("SELECTOR_GROUPS", []):
+        gid = grp.get("group_id")
+        if gid is None:
+            continue
+        groups[int(gid)] = {
+            "on_color": grp.get("on_color"),
+            "off_color": grp.get("off_color"),
+            "members": [],
+        }
+
     for entry in data.get("NOTE", []):
         chan = entry.get("channel")
         note = entry.get("note")
         if chan is None or note is None:
             continue
         filters["NOTE"].setdefault(chan, {})[note] = entry
+        gid = entry.get("group")
+        if gid is not None:
+            groups.setdefault(int(gid), {"on_color": None, "off_color": None, "members": []})[
+                "members"
+            ].append(("NOTE", int(note)))
 
     for entry in data.get("CC", []):
         chan = entry.get("channel")
@@ -48,11 +71,58 @@ def _load_launchkey_filters(path):
         if chan is None or cc is None:
             continue
         filters["CC"].setdefault(chan, {})[cc] = entry
+        gid = entry.get("group")
+        if gid is not None:
+            groups.setdefault(int(gid), {"on_color": None, "off_color": None, "members": []})[
+                "members"
+            ].append(("CC", int(cc)))
+
+    global LAUNCHKEY_GROUPS
+    LAUNCHKEY_GROUPS = groups
 
     return filters
 
 
+LAUNCHKEY_GROUPS = {}
 LAUNCHKEY_FILTERS = _load_launchkey_filters(_config_path)
+
+
+def _send_color(outport, section, pid, color, mode="static"):
+    """Send a color update to the Launchkey for a pad or control."""
+
+    if color is None:
+        return
+
+    mode_alias = {"static": "stationary"}
+    mode_to_channel = {"stationary": 0, "flashing": 1, "pulsing": 2}
+    colormode = mode_alias.get(mode, mode)
+    chan = mode_to_channel.get(colormode, 0)
+    val = max(0, min(int(color), 127))
+    pid = int(pid) & 0x7F
+
+    if section == "NOTE":
+        msg = mido.Message("note_on", channel=chan, note=pid, velocity=val)
+    else:
+        msg = mido.Message("control_change", channel=chan, control=pid, value=val)
+    outport.send(msg)
+
+
+def _apply_group_colors(outport, section, pid, group_id, mode="static"):
+    """Color helper for selector groups."""
+
+    group = LAUNCHKEY_GROUPS.get(int(group_id))
+    if not group:
+        return
+
+    on_color = group.get("on_color")
+    off_color = group.get("off_color")
+
+    _send_color(outport, section, pid, on_color, mode)
+
+    for sec, member_pid in group.get("members", []):
+        if sec == section and member_pid == pid:
+            continue
+        _send_color(outport, sec, member_pid, off_color, mode)
 
 
 # --- Master port filter ---------------------------------------------------
@@ -126,6 +196,17 @@ def filter_and_translate_launchkey_daw_msg(msg, daw_outport, state_manager, verb
                 send_sysex_to_ketron(_ketron_outport, data)
                 if verbose:
                     print(f"[LAUNCHKEY-DAW-FILTER] NOTE -> TABS {name} {'ON' if is_on else 'OFF'}")
+
+            if is_on:
+                group_id = rule.get("group")
+                if group_id is not None:
+                    _apply_group_colors(
+                        daw_outport,
+                        "NOTE",
+                        msg.note,
+                        group_id,
+                        rule.get("colormode", "static"),
+                    )
         elif verbose:
             print(
                 f"[LAUNCHKEY-DAW-FILTER] Nessuna regola per nota {msg.note} canale {msg.channel}"
@@ -157,6 +238,16 @@ def filter_and_translate_launchkey_daw_msg(msg, daw_outport, state_manager, verb
                     if verbose:
                         print(
                             f"[LAUNCHKEY-DAW-FILTER] CC {msg.control} -> TABS {name}"
+                        )
+                if msg.value > 0:
+                    group_id = rule.get("group")
+                    if group_id is not None:
+                        _apply_group_colors(
+                            daw_outport,
+                            "CC",
+                            msg.control,
+                            group_id,
+                            rule.get("colormode", "static"),
                         )
             elif rtype == "CC" and "newval" in rule:
                 _ketron_outport.send(msg)


### PR DESCRIPTION
## Summary
- allow defining selector groups with shared on/off colors in `launchkey_config.json`
- send automatic LED updates for selector groups in `launchkey_midi_filter`

## Testing
- `python -m py_compile launchkey_midi_filter.py`
- `python tests/manual_launchkey_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_689df49faa248323bfe2f26b9163ed88