### PR TITLE
Support TAB LED updates via Ketron Sysex

### DIFF
--- a/launchkey_config.json
+++ b/launchkey_config.json
@@ -23,7 +23,7 @@
     { "note":  98,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 3", "group": 2, "color": 0, "colormode": "static" },
     { "note":  99,  "channel": 0,  "type": "FOOTSWITCH", "name": "STYLE VOICE 4", "group": 2, "color": 0, "colormode": "static" },
     { "note": 100,  "channel": 0,  "type": "TABS", "name": "PIANIST", "color": 46, "colormode": "static" },
-    { "note": 102,  "channel": 0,  "type": "FOOTSWITCH", "name": "MICRO1 ON/OFF", "color": 5, "colormode": "static" },
+    { "note": 102,  "channel": 0,  "type": "FOOTSWITCH", "name": "MICRO1 ON/OFF", "color": 5, "colormode": "static", "tabs_led": "MICRO", "tabs_led_off_color": 7 },
     { "note": 103,  "channel": 0,  "type": "FOOTSWITCH", "name": "VOICETR.ON/OFF", "color": 69, "colormode": "static" },
     { "note": 112,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.A", "group": 1, "color": 13, "colormode": "static" },
     { "note": 113,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.B", "group": 1, "color": 13, "colormode": "static" },

--- a/main.py
+++ b/main.py
@@ -13,12 +13,13 @@ def main():
         default='fantom',
         help='Specifica la master keyboard collegata'
     )
+    parser.add_argument('--tabs', action='store_true', help='Abilita la lettura degli eventi TAB')
     args = parser.parse_args()
 
     app = QtWidgets.QApplication(sys.argv)
 
     # Lo StateManager gestisce tutto lo stato, i led, e il logging
-    state_manager = StateManager(verbose=args.verbose, master=args.master)
+    state_manager = StateManager(verbose=args.verbose, master=args.master, tabs=args.tabs)
     led_bar = LedBar(states_getter=state_manager.get_led_states)
     state_manager.set_ledbar(led_bar)
     led_bar.set_state_manager(state_manager)


### PR DESCRIPTION
## Summary
- add `--tabs` option to enable TAB sysex listener
- map TAB names to Launchkey LEDs and control their colors
- allow config entries with `tabs_led` and optional off color

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a03398dfb883238db26d55503ed280