### PR TITLE
Fix Launchkey DAW reconnection after Ketron restart

### DIFF
--- a/statemanager.py
+++ b/statemanager.py
@@ -343,8 +343,14 @@ class StateManager(QtCore.QObject):
         if self.daw_listener_stop:
             self.daw_listener_stop.set()
         self.daw_listener_thread = None
-        # Reset Launchkey DAW filter's Ketron outport
-        launchkey_midi_filter._ketron_outport
+        # Reset Launchkey DAW filter's Ketron outport so a new connection
+        # can be established after disconnections or device restarts.
+        try:
+            if launchkey_midi_filter._ketron_outport:
+                launchkey_midi_filter._ketron_outport.close()
+        except Exception:
+            pass
+        launchkey_midi_filter._ketron_outport = None
 
     # -------- Master MIDI methods --------
     def start_master_listener(self):


### PR DESCRIPTION
## Summary
- Ensure DAW listener resets Ketron outport on stop so Launchkey DAW can reconnect after device power cycles

## Testing
- `python -m py_compile statemanager.py launchkey_midi_filter.py`
- `python tests/manual_launchkey_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2f70df0608323af055ac7d22b032f