### PR TITLE
Prevent duplicate messages after device reconnect

### DIFF
--- a/statemanager.py
+++ b/statemanager.py
@@ -342,6 +342,9 @@ class StateManager(QtCore.QObject):
     def stop_daw_listener(self):
         if self.daw_listener_stop:
             self.daw_listener_stop.set()
+        thread = self.daw_listener_thread
+        if thread:
+            thread.join(timeout=1)
         self.daw_listener_thread = None
         # Reset Launchkey DAW filter's Ketron outport so a new connection
         # can be established after disconnections or device restarts.
@@ -396,4 +399,7 @@ class StateManager(QtCore.QObject):
     def stop_master_listener(self):
         if hasattr(self, "master_listener_stop") and self.master_listener_stop:
             self.master_listener_stop.set()
+        thread = getattr(self, "master_listener_thread", None)
+        if thread:
+            thread.join(timeout=1)
         self.master_listener_thread = None


### PR DESCRIPTION
## Summary
- ensure DAW listener thread joins before clearing
- wait for master listener thread to exit to avoid duplicate forwarding

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33f426cc883239c184e22d690c17e