### PR TITLE
Add Launchkey display routine and git-based version info

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,12 +13,21 @@ def main():
         default='fantom',
         help='Specifica la master keyboard collegata'
     )
+    parser.add_argument(
+        '--disable_realtime_display',
+        action='store_true',
+        help='Disabilita la visualizzazione dei messaggi di controllo in tempo reale'
+    )
     args = parser.parse_args()
 
     app = QtWidgets.QApplication(sys.argv)
 
     # Lo StateManager gestisce tutto lo stato, i led, e il logging
-    state_manager = StateManager(verbose=args.verbose, master=args.master)
+    state_manager = StateManager(
+        verbose=args.verbose,
+        master=args.master,
+        disable_realtime_display=args.disable_realtime_display,
+    )
     led_bar = LedBar(states_getter=state_manager.get_led_states)
     state_manager.set_ledbar(led_bar)
     led_bar.set_state_manager(state_manager)

--- a/statemanager.py
+++ b/statemanager.py
@@ -12,10 +12,16 @@ from launchkey_midi_filter import (
 from PyQt5 import QtCore
 
 class StateManager(QtCore.QObject):
-    def __init__(self, verbose=False, master="fantom"):
+    def __init__(
+        self,
+        verbose=False,
+        master="fantom",
+        disable_realtime_display=False,
+    ):
         super().__init__()
         self.verbose = verbose
         self.master = master
+        self.disable_realtime_display = disable_realtime_display
         self.ledbar = None
         self.master_port = None
         self.ketron_port = None
@@ -284,18 +290,7 @@ class StateManager(QtCore.QObject):
                     if self.verbose:
                         print(f"[DAW] Inviato init: {init_msg}")
 
-                    # Display DEFAULT
-                    hdr = [0x00, 0x20, 0x29, 0x02, 0x12, 0x04]
-                    txt_1 = "   Ketron EVM   "
-                    txt_2 = " Armonix v. 1.0 "
-                    data = hdr + [0x00] + [ord(c) & 0x7F for c in txt_1]
-                    if self.verbose:
-                        print(f"[DAW] set default display sysex {data}")
-                    outport.send(mido.Message("sysex", data=data))
-                    data = hdr + [0x01] + [ord(c) & 0x7F for c in txt_2]
-                    if self.verbose:
-                        print(f"[DAW] set default display sysex {data}")
-                    outport.send(mido.Message("sysex", data=data))
+                    launchkey_midi_filter.init_default_display(outport, verbose=self.verbose)
 
                     # coloro i pulsanti che hanno la configurazione
                     mode_to_channel = { "stationary": 0, "flashing": 1, "pulsing": 2 }


### PR DESCRIPTION
## Summary
- add CLI flag to disable real-time display messages
- centralize Launchkey display management with git commit-based version and date
- show temporary control info on Launchkey display and restore default after 3s

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a560ab43b483238f739c1f10430c94