### PR TITLE
Add toggle support for custom Launchkey controls

### DIFF
--- a/launchkey_config.json
+++ b/launchkey_config.json
@@ -41,7 +41,7 @@
     { "control": 105,  "channel":  0,  "type": "FOOTSWITCH", "name": "TALK ON/OFF" , "color": 1},
     { "control": 106,  "channel": 15,  "type": "FOOTSWITCH", "name": "VOICE UP", "color": 47},
     { "control": 107,  "channel": 15,  "type": "FOOTSWITCH", "name": "VOICE DOWN", "color": 47},
-    { "control": 108,  "channel": 15,  "type": "FOOTSWITCH", "name": "VOICETR.ON/OFF", "color": 3 },
+    { "control": 108,  "channel": 15,  "type": "CUSTOM", "name": "VOICETRON SWITCH", "color_on": 3, "color_off": 0 },
     { "control": 37,   "channel": 15,  "type": "FOOTSWITCH", "name": "Drum Mute", "color": 15 },
     { "control": 53,   "channel": 15,  "type": "CC", "newval": 104, "name": "Drum", "lcd_index": 80 },
     { "control": 38,   "channel": 15,  "type": "FOOTSWITCH", "name": "Bass Mute", "color": 7 },

--- a/statemanager.py
+++ b/statemanager.py
@@ -292,6 +292,8 @@ class StateManager(QtCore.QObject):
 
                     launchkey_midi_filter.init_default_display(outport, verbose=self.verbose)
 
+                    launchkey_midi_filter.CUSTOM_TOGGLE_STATES.clear()
+
                     # coloro i pulsanti che hanno la configurazione
                     mode_to_channel = { "stationary": 0, "flashing": 1, "pulsing": 2 }
                     mode_alias = { "static": "stationary" }
@@ -303,7 +305,11 @@ class StateManager(QtCore.QObject):
                         for ch, id_map in ch_map.items():
                             for pid, meta in id_map.items():  # pid = note/control
                                 color = meta.get("color")
-                                if color:
+                                if color is None:
+                                    color = meta.get("color_off")
+                                    if color is None:
+                                        color = meta.get("color_on")
+                                if color is not None:
                                     raw_mode  = meta.get("colormode", "stationary")
                                     colormode = mode_alias.get(raw_mode, raw_mode)
 


### PR DESCRIPTION
## Summary
- allow Launchkey DAW filter to handle CUSTOM actions with on/off states and LED color updates
- store custom toggle states and reset them when DAW port connects
- initialize pad colors with `color_on`/`color_off` from config and add VOICETRON SWITCH entry

## Testing
- `python -m py_compile launchkey_midi_filter.py statemanager.py custom_sysex_lookup.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a586f555ec832396c40bc1a6989c2b