### PR TITLE
Fix color assignment dialog initialization

### DIFF
--- a/color_launchkey.py
+++ b/color_launchkey.py
@@ -132,8 +132,6 @@ class AssignmentDialog(QtWidgets.QDialog):
         self.type_box = QtWidgets.QComboBox()
         self.type_box.addItems(["TABS", "FOOTSWITCH", "CUSTOM"])
         self.action_box = QtWidgets.QComboBox()
-        self.type_box.currentTextChanged.connect(self._populate_actions)
-        self._populate_actions(self.type_box.currentText())
 
         self.color_btn = QtWidgets.QPushButton("Colore")
         self.color_btn.clicked.connect(self._pick_color)
@@ -141,6 +139,9 @@ class AssignmentDialog(QtWidgets.QDialog):
         self.color_on_btn.clicked.connect(lambda: self._pick_color("on"))
         self.color_off_btn = QtWidgets.QPushButton("Colore OFF")
         self.color_off_btn.clicked.connect(lambda: self._pick_color("off"))
+
+        self.type_box.currentTextChanged.connect(self._populate_actions)
+        self._populate_actions(self.type_box.currentText())
 
         self.color = None
         self.color_on = None


### PR DESCRIPTION
## Summary
- Ensure AssignmentDialog creates color buttons before populating actions
- Prevent AttributeError on key press when running color_launchkey with `--debug`

## Testing
- `python -m py_compile color_launchkey.py`
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a720f78a788323b613f5404599d32e