### PR TITLE
Add velocity-aware custom sysex pads

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,48 @@ vengono inoltrati al Ketron, mentre gli altri vengono scartati.
 
 Il file `keypad_config.json` definisce la mappatura tra i tasti del tastierino e i messaggi Sysex o Footswitch da inviare al Ketron. È possibile modificare questo file per adattare i comandi alle proprie esigenze.
 
+## Pulsanti CUSTOM con livelli di velocità
+
+È possibile associare ai pad della Launchkey messaggi Sysex differenti a seconda della **velocity** ricevuta. Nel file
+`custom_sysex_lookup.py` si definiscono più livelli tramite la chiave `levels`, specificando per ciascuno:
+
+- intervallo di velocity (`min`/`max`)
+- nome visualizzato
+- colore opzionale del pad
+- lista di messaggi Sysex da inviare
+
+Esempio semplificato:
+
+```python
+"ARRA_A_BREAK": {
+    "levels": [
+        {
+            "name": "ARRA_A_BREAK",
+            "min": 100,
+            "max": 127,
+            "color": 23,
+            "sysex": [ [0x26, 0x79, 0x03, 0x03, 0x7F] ]
+        },
+        {
+            "name": "NOTE_A",
+            "min": 1,
+            "max": 99,
+            "color": 5,
+            "sysex": [ [0x26, 0x79, 0x03, 0x03, 0x7F] ]
+        }
+    ]
+}
+```
+
+Nel `launchkey_config.json` basta poi mappare il pad con `"type": "CUSTOM"` e il relativo `name`:
+
+```json
+{ "note": 112, "channel": 0, "type": "CUSTOM", "name": "ARRA_A_BREAK", "group": 1, "color": 23, "colormode": "static" }
+```
+
+Se un livello definisce un colore, questo sovrascrive quello standard; in caso contrario viene usato il comportamento normale
+del gruppo o quello indicato nella configurazione.
+
 ## Adattamenti ad altri setup
 
 La logica è suddivisa in moduli (gestione dello stato, filtro MIDI, listener per il tastierino), rendendo relativamente semplice l'estensione a strumenti o controller diversi. Basterà modificare le mappature e, se necessario, aggiungere nuovi filtri MIDI.

--- a/custom_sysex_lookup.py
+++ b/custom_sysex_lookup.py
@@ -41,4 +41,37 @@ CUSTOM_SYSEX_LOOKUP = {
             "on": 0x01
         }
     },
+    "ARRA_A_BREAK": {
+        "levels": [
+            {
+                "name": "ARRA_A_BREAK",
+                "min": 100,
+                "max": 127,
+                "color": 23,
+                "sysex": [
+                    [0x26, 0x79, 0x03, 0x03, 0x7F],
+                    [0x26, 0x79, 0x03, 0x16, 0x7F],
+                    [0x26, 0x79, 0x03, 0x16, 0x00],
+                ],
+            },
+            {
+                "name": "NOTE_A",
+                "min": 1,
+                "max": 99,
+                "color": 5,
+                "sysex": [
+                    [0x26, 0x79, 0x03, 0x03, 0x7F],
+                ],
+            },
+            {
+                "name": "NOTE_A",
+                "min": 0,
+                "max": 0,
+                "color": 0,
+                "sysex": [
+                    [0x26, 0x79, 0x03, 0x03, 0x00],
+                ],
+            },
+        ],
+    },
 }

--- a/launchkey_config.json
+++ b/launchkey_config.json
@@ -25,7 +25,7 @@
     { "note": 100,  "channel": 0,  "type": "TABS", "name": "PIANIST", "color": 45, "colormode": "static" },
     { "note": 102,  "channel": 0,  "type": "CUSTOM", "name": "MICRO 1 SWITCH", "color": 4, "color_on": 5, "color_off": 7,"colormode": "static" },
     { "note": 103,  "channel": 0,  "type": "CUSTOM", "name": "VOICETRON SWITCH", "color": 52, "color_on": 53, "color_off": 55, "colormode": "static" },
-    { "note": 112,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.A", "group": 1, "color": 23, "colormode": "static" },
+    { "note": 112,  "channel": 0,  "type": "CUSTOM", "name": "ARRA_A_BREAK", "group": 1, "color": 23, "colormode": "static" },
     { "note": 113,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.B", "group": 1, "color": 23, "colormode": "static" },
     { "note": 114,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.C", "group": 1, "color": 23, "colormode": "static" },
     { "note": 115,  "channel": 0,  "type": "FOOTSWITCH", "name": "ARR.D", "group": 1, "color": 23, "colormode": "static" },


### PR DESCRIPTION
## Summary
- support velocity-based custom pad actions with optional color overrides
- handle new velocity levels in Launchkey DAW filter
- document custom pad levels and add ARRA_A_BREAK example configuration

## Testing
- `python -m py_compile custom_sysex_lookup.py launchkey_midi_filter.py`
- `python tests/manual_launchkey_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_68aaad914ac8832381161a6b746aecff