### PR TITLE
Add headless mode without PyQt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ other environments with minimal effort.
 2. Install the main dependencies:
 
    ```bash
-   pip install mido python-rtmidi PyQt5 evdev
+   pip install mido python-rtmidi evdev
+   # Facoltativo per la barra LED grafica:
+   pip install PyQt5
    ```
 
 ## Running
@@ -37,6 +39,13 @@ Run it with:
 
 ```bash
 python main.py --verbose
+```
+
+To run Armonix on a machine without a display (and without installing
+PyQt5) use the headless option:
+
+```bash
+python main.py --headless
 ```
 
 Two helper scripts are included:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import sys
 import argparse
-from PyQt5 import QtWidgets
-from ledbar import LedBar
+import time
+
 from statemanager import StateManager
 
 def main():
@@ -18,9 +18,12 @@ def main():
         action='store_true',
         help='Disabilita la visualizzazione dei messaggi di controllo in tempo reale'
     )
+    parser.add_argument(
+        '--headless',
+        action='store_true',
+        help='Esegui senza GUI e senza dipendenze PyQt5'
+    )
     args = parser.parse_args()
-
-    app = QtWidgets.QApplication(sys.argv)
 
     # Lo StateManager gestisce tutto lo stato, i led, e il logging
     state_manager = StateManager(
@@ -28,11 +31,22 @@ def main():
         master=args.master,
         disable_realtime_display=args.disable_realtime_display,
     )
-    led_bar = LedBar(states_getter=state_manager.get_led_states)
-    state_manager.set_ledbar(led_bar)
-    led_bar.set_state_manager(state_manager)
 
-    sys.exit(app.exec_())
+    if args.headless:
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            pass
+    else:
+        from PyQt5 import QtWidgets
+        from ledbar import LedBar
+
+        app = QtWidgets.QApplication(sys.argv)
+        led_bar = LedBar(states_getter=state_manager.get_led_states)
+        state_manager.set_ledbar(led_bar)
+        led_bar.set_state_manager(state_manager)
+        sys.exit(app.exec_())
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- Allow running Armonix without PyQt5 using a new `--headless` CLI flag
- Make `StateManager` fall back to a simple thread loop when Qt is unavailable
- Document optional PyQt5 dependency and headless mode in README

## Testing
- `python -m pytest`
- `python main.py --headless` *(fails: ModuleNotFoundError: No module named 'mido')*
- `pip install mido` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b47541c7bc8323a7aa57af16c7436e