### PR TITLE
Fix QTimer initialization when PyQt5 not started

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,14 +25,13 @@ def main():
     )
     args = parser.parse_args()
 
-    # Lo StateManager gestisce tutto lo stato, i led, e il logging
-    state_manager = StateManager(
-        verbose=args.verbose,
-        master=args.master,
-        disable_realtime_display=args.disable_realtime_display,
-    )
-
     if args.headless:
+        # Lo StateManager gestisce tutto lo stato, i led, e il logging
+        state_manager = StateManager(
+            verbose=args.verbose,
+            master=args.master,
+            disable_realtime_display=args.disable_realtime_display,
+        )
         try:
             while True:
                 time.sleep(1)
@@ -43,6 +42,11 @@ def main():
         from ledbar import LedBar
 
         app = QtWidgets.QApplication(sys.argv)
+        state_manager = StateManager(
+            verbose=args.verbose,
+            master=args.master,
+            disable_realtime_display=args.disable_realtime_display,
+        )
         led_bar = LedBar(states_getter=state_manager.get_led_states)
         state_manager.set_ledbar(led_bar)
         led_bar.set_state_manager(state_manager)

--- a/statemanager.py
+++ b/statemanager.py
@@ -28,7 +28,7 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
         self.ketron_port = None
         self.ble_port = None
         self.state = "waiting"   # 'waiting', 'ready', 'paused'
-        if QT_AVAILABLE:
+        if QT_AVAILABLE and QtCore.QCoreApplication.instance() is not None:
             self.timer = QtCore.QTimer()
             self.timer.timeout.connect(self.poll_ports)
             self.timer.start(1000)  # Ogni secondo


### PR DESCRIPTION
## Summary
- Avoid starting QTimer before a Qt application exists
- Initialize QApplication before StateManager in GUI mode

## Testing
- `python -m py_compile main.py statemanager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b822b4a82c8323bd68d367faf15781