### PR TITLE
Add NRPN support for keypad microphone presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,27 @@ forwarded to the Ketron while others are discarded.
 
 ## Keypad configuration
 
-`keypad_config.json` defines the mapping between keypad keys and Sysex or
-Footswitch messages sent to the Ketron.  Modify this file to adapt the
-commands to your needs.
+`keypad_config.json` defines the mapping between keypad keys and Sysex,
+Footswitch or NRPN messages sent to the Ketron.  Modify this file to
+adapt the commands to your needs.
+
+### NRPN commands
+
+NRPN presets for the Ketron microphone section are listed in
+`nrpn_lookup.py`.  Each entry exposes the NRPN MSB/LSB address and the
+available values.  To trigger one of these presets from the keypad add a
+mapping with `"type": "NRPN"` and specify the target preset with the
+`value` field:
+
+```json
+"KEY_U": { "type": "NRPN", "name": "MICRO_PRESET", "value": "Standard" }
+```
+
+When the configured key is pressed the keypad sends the appropriate
+Control Change sequence (`CC 99`, `CC 98`, `CC 06`) on MIDI channel 16.
+The `value` field accepts both the human readable name and a raw integer
+between 0 and 127, allowing custom presets to be added without modifying
+the lookup table.
 
 ## Custom pads with velocity levels
 

--- a/keypad_config.json
+++ b/keypad_config.json
@@ -16,5 +16,9 @@
   "KEY_Q": { "type": "FOOTSWITCH", "name": "DIAL_UP" },
   "KEY_R": { "type": "FOOTSWITCH", "name": "TEMPO DOWN" },
   "KEY_S": { "type": "FOOTSWITCH", "name": "START/STOP" },
-  "KEY_T": { "type": "FOOTSWITCH", "name": "TEMPO UP" }
+  "KEY_T": { "type": "FOOTSWITCH", "name": "TEMPO UP" },
+  "KEY_U": { "type": "NRPN", "name": "MICRO_PRESET", "value": "Standard" },
+  "KEY_V": { "type": "NRPN", "name": "MICRO_COMPRESSOR_PRESET", "value": "OFF" },
+  "KEY_W": { "type": "NRPN", "name": "MICRO_EQ_PRESET", "value": "OFF" },
+  "KEY_X": { "type": "NRPN", "name": "MICRO_ECHO_PRESET", "value": "Standard" }
 }

--- a/nrpn_lookup.py
+++ b/nrpn_lookup.py
@@ -1,0 +1,114 @@
+"""Lookup tables for NRPN commands handled by the keypad controller.
+
+Each entry defines the NRPN address (MSB/LSB) and the available values.
+The values dictionary maps human readable names to the integer value that
+must be sent as Data Entry MSB (Control Change 06h).
+"""
+
+NRPN_LOOKUP = {
+    "MICRO_PRESET": {
+        "msb": 0x70,
+        "lsb": 0x21,
+        "values": {
+            "Standard": 0x00,
+            "Mellow": 0x01,
+            "Small": 0x02,
+            "Large": 0x03,
+            "Gated": 0x04,
+            "Live": 0x05,
+            "Solo Echo": 0x06,
+            "Special Efx1": 0x07,
+            "Special Efx2": 0x08,
+            "Double Voice": 0x09,
+            "User 01": 0x0A,
+            "User 02": 0x0B,
+            "User 03": 0x0C,
+            "User 04": 0x0D,
+            "User 05": 0x0E,
+            "User 06": 0x0F,
+            "User 07": 0x10,
+            "User 08": 0x11,
+            "User 09": 0x12,
+            "User 10": 0x13,
+        },
+    },
+    "MICRO_COMPRESSOR_PRESET": {
+        "msb": 0x70,
+        "lsb": 0x40,
+        "values": {
+            "OFF": 0x00,
+            "compr -15dB 2:1": 0x01,
+            "compr -18dB 3:1": 0x02,
+            "compr -21dB 7:1": 0x03,
+            "compr -18dB 2:1": 0x04,
+            "compr -24dB 2:1": 0x05,
+            "limiter -6dB": 0x06,
+            "limiter -18dB": 0x07,
+        },
+    },
+    "MICRO_EQ_PRESET": {
+        "msb": 0x70,
+        "lsb": 0x6B,
+        "values": {
+            "OFF": 0x00,
+            "Male": 0x01,
+            "Female": 0x02,
+            "Robot": 0x03,
+            "Duck": 0x04,
+            "Bear": 0x05,
+            "Mouse": 0x06,
+            "Dark": 0x07,
+            "Cartoon": 0x08,
+            "Doubling Choir": 0x09,
+        },
+    },
+    "MICRO_ECHO_PRESET": {
+        "msb": 0x70,
+        "lsb": 0x30,
+        "values": {
+            "Standard": 0x00,
+            "Flat": 0x01,
+            "Brilliance": 0x02,
+            "Studio": 0x03,
+            "User 01": 0x04,
+            "User 02": 0x05,
+            "User 03": 0x06,
+            "User 04": 0x07,
+        },
+    },
+}
+
+
+def resolve_nrpn_value(name, value_key):
+    """Return the NRPN address/value tuple for the requested preset.
+
+    Parameters
+    ----------
+    name: str
+        Identifier of the NRPN command, as defined in ``NRPN_LOOKUP``.
+    value_key: str | int
+        Human readable preset name or integer value.  When an integer is
+        provided it is returned as-is, allowing advanced users to bypass
+        the lookup table.
+
+    Returns
+    -------
+    tuple[int, int, int] | None
+        A tuple ``(msb, lsb, value)`` or ``None`` if the lookup fails.
+    """
+
+    entry = NRPN_LOOKUP.get(name)
+    if not entry:
+        return None
+
+    if isinstance(value_key, int):
+        if 0 <= value_key <= 0x7F:
+            return entry["msb"], entry["lsb"], value_key
+        return None
+
+    if isinstance(value_key, str):
+        value = entry["values"].get(value_key)
+        if value is not None:
+            return entry["msb"], entry["lsb"], value
+
+    return None


### PR DESCRIPTION
## Summary
- add an NRPN lookup table covering microphone presets, compressor, EQ and echo values
- extend the keypad callback to emit NRPN control change sequences and expose examples in the keypad config
- document the new capability and provide usage guidance in the README

## Testing
- python -m compileall keypad_midi_callback.py nrpn_lookup.py

------
https://chatgpt.com/codex/tasks/task_e_68d004336a28832392346c219b342ea1