### PR TITLE
Avoid git queries when repository metadata missing

### DIFF
--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -129,18 +129,23 @@ def _send_display(outport, line1, line2, verbose=False):
 def init_default_display(outport, verbose=False):
     """Compute default message with git info and show it."""
     global _default_lines
-    try:
-        version = subprocess.check_output(
-            ["git", "rev-list", "--count", "HEAD"], cwd=base_dir
-        ).decode().strip()
-    except Exception:
+    git_dir = os.path.join(base_dir, ".git")
+    if os.path.isdir(git_dir):
+        try:
+            version = subprocess.check_output(
+                ["git", "rev-list", "--count", "HEAD"], cwd=base_dir
+            ).decode().strip()
+        except Exception:
+            version = "0"
+        try:
+            date = subprocess.check_output(
+                ["git", "log", "-1", "--format=%cd", "--date=format:%d/%m/%Y"],
+                cwd=base_dir,
+            ).decode().strip()
+        except Exception:
+            date = datetime.now().strftime("%d/%m/%Y")
+    else:
         version = "0"
-    try:
-        date = subprocess.check_output(
-            ["git", "log", "-1", "--format=%cd", "--date=format:%d/%m/%Y"],
-            cwd=base_dir,
-        ).decode().strip()
-    except Exception:
         date = datetime.now().strftime("%d/%m/%Y")
     line1 = "Armonix".center(16)
     line2 = f"{date} v{version}".center(16)


### PR DESCRIPTION
## Summary
- skip git metadata lookups for the Launchkey default display when the application is not running inside a git checkout
- fall back to a neutral version number and the current date when git data is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15121e7448323a273941b97963694