### PR TITLE
Bump Debian version to 0.99.7 and ensure GUI autostarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME := armonix
-VERSION := 0.99.1
+VERSION := $(shell python3 -c "from version import __version__; print(__version__)")
 BUILD_DIR := build/deb
 PKG_DIR := $(BUILD_DIR)/$(PKG_NAME)_$(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Raspberry Pi and Debian/Ubuntu systems:
 make deb
 ```
 
-The command produces `build/deb/armonix_0.99.deb`.  The package installs
+The command produces `build/deb/armonix_0.99.7.deb`.  The package installs
 Armonix under `/usr/lib/armonix`, deploys configuration files in
 `/etc/armonix` and registers a `systemd` service (`armonix.service`) that
 starts the application at boot as the dedicated user `armonix`.

--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -1,10 +1,7 @@
 import json
 import logging
-import os
 import re
-import subprocess
 import threading
-from datetime import datetime
 
 import mido
 
@@ -19,6 +16,7 @@ from sysex_utils import (
 )
 from custom_sysex_lookup import CUSTOM_SYSEX_LOOKUP
 from paths import get_config_path
+from version import __version__ as ARMONIX_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +27,6 @@ DAW_OUT_PORT_KEYWORD = "Launchkey MK3 88 LKMK3 DAW In"
 
 # --- Config loading -------------------------------------------------------
 
-base_dir = os.path.dirname(os.path.abspath(__file__))
 _config_path = get_config_path("launchkey_config.json")
 
 
@@ -127,28 +124,11 @@ def _send_display(outport, line1, line2, verbose=False):
 
 
 def init_default_display(outport, verbose=False):
-    """Compute default message with git info and show it."""
+    """Show the application version on the Launchkey display."""
+
     global _default_lines
-    git_dir = os.path.join(base_dir, ".git")
-    if os.path.isdir(git_dir):
-        try:
-            version = subprocess.check_output(
-                ["git", "rev-list", "--count", "HEAD"], cwd=base_dir
-            ).decode().strip()
-        except Exception:
-            version = "0"
-        try:
-            date = subprocess.check_output(
-                ["git", "log", "-1", "--format=%cd", "--date=format:%d/%m/%Y"],
-                cwd=base_dir,
-            ).decode().strip()
-        except Exception:
-            date = datetime.now().strftime("%d/%m/%Y")
-    else:
-        version = "0"
-        date = datetime.now().strftime("%d/%m/%Y")
     line1 = "Armonix".center(16)
-    line2 = f"{date} v{version}".center(16)
+    line2 = f"v. {ARMONIX_VERSION}".center(16)
     _default_lines = (line1[:16], line2[:16])
     _send_display(outport, *_default_lines, verbose=verbose)
 

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from configuration import load_config
 from session_utils import build_session_environment, find_active_graphical_session
 from statemanager import StateManager
 from wifi_vnc import WifiVncLauncher
+from version import __version__ as ARMONIX_VERSION
 
 
 class _LoggerWriter:
@@ -240,7 +241,8 @@ def main(argv: Optional[list[str]] = None) -> None:
     sys.stderr = _LoggerWriter(logging.ERROR)
 
     logger.info(
-        "Armonix 0.99 avviato (config=%s, master=%s, modalità=%s)",
+        "Armonix %s avviato (config=%s, master=%s, modalità=%s)",
+        ARMONIX_VERSION,
         args.config,
         args.master,
         "headless" if args.headless else "gui",

--- a/man/armonix.1
+++ b/man/armonix.1
@@ -1,5 +1,5 @@
 ." Manpage for Armonix
-.TH ARMONIX 1 "March 2024" "Version 0.99" "User Commands"
+.TH ARMONIX 1 "March 2024" "Version 0.99.7" "User Commands"
 .SH NAME
 armonix \- controller MIDI per tastiere Ketron
 .SH SYNOPSIS

--- a/packaging/armonix-gui.service
+++ b/packaging/armonix-gui.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Armonix GUI and VNC helper (user session)
 PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=simple
@@ -9,4 +10,4 @@ Restart=on-failure
 Environment=PYTHONUNBUFFERED=1
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -18,6 +18,15 @@ if command -v systemctl >/dev/null 2>&1; then
     if [ "$1" = "configure" ]; then
         systemctl enable armonix.service >/dev/null 2>&1 || true
         systemctl restart armonix.service >/dev/null 2>&1 || true
+        systemctl --global enable armonix-gui.service >/dev/null 2>&1 || true
+        if command -v loginctl >/dev/null 2>&1; then
+            loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
+                [ -z "$user" ] && continue
+                [ "$user" = "root" ] && continue
+                runuser -l "$user" -c "systemctl --user daemon-reload >/dev/null 2>&1 || true" || true
+                runuser -l "$user" -c "systemctl --user enable --now armonix-gui.service >/dev/null 2>&1 || true" || true
+            done || true
+        fi
     fi
 fi
 

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -5,6 +5,14 @@ if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload >/dev/null 2>&1 || true
     if [ "$1" = "remove" ]; then
         systemctl disable armonix.service >/dev/null 2>&1 || true
+        systemctl --global disable armonix-gui.service >/dev/null 2>&1 || true
+        if command -v loginctl >/dev/null 2>&1; then
+            loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
+                [ -z "$user" ] && continue
+                [ "$user" = "root" ] && continue
+                runuser -l "$user" -c "systemctl --user disable armonix-gui.service >/dev/null 2>&1 || true" || true
+            done || true
+        fi
     fi
 fi
 

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -4,6 +4,13 @@ set -e
 if command -v systemctl >/dev/null 2>&1; then
     if [ "$1" = "remove" ] || [ "$1" = "upgrade" ]; then
         systemctl stop armonix.service >/dev/null 2>&1 || true
+        if command -v loginctl >/dev/null 2>&1; then
+            loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
+                [ -z "$user" ] && continue
+                [ "$user" = "root" ] && continue
+                runuser -l "$user" -c "systemctl --user stop armonix-gui.service >/dev/null 2>&1 || true" || true
+            done || true
+        fi
     fi
 fi
 

--- a/version.py
+++ b/version.py
@@ -1,0 +1,3 @@
+"""Armonix package version metadata."""
+
+__version__ = "0.99.7"


### PR DESCRIPTION
## Summary
- bump the Debian package metadata to version 0.99.7 and expose it through a shared Python module
- show the packaged version in the GUI log and on the Launchkey display instead of git metadata
- enable and manage the armonix-gui user service during install/removal so it starts for desktop sessions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16e295cdc8323ba59f88a33b44bbe