### PR TITLE
Fix global enable of GUI user service

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -18,7 +18,7 @@ if command -v systemctl >/dev/null 2>&1; then
     if [ "$1" = "configure" ]; then
         systemctl enable armonix.service >/dev/null 2>&1 || true
         systemctl restart armonix.service >/dev/null 2>&1 || true
-        systemctl --global enable armonix-gui.service >/dev/null 2>&1 || true
+        systemctl --user --global enable armonix-gui.service >/dev/null 2>&1 || true
         if command -v loginctl >/dev/null 2>&1; then
             loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
                 [ -z "$user" ] && continue

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -5,7 +5,7 @@ if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload >/dev/null 2>&1 || true
     if [ "$1" = "remove" ]; then
         systemctl disable armonix.service >/dev/null 2>&1 || true
-        systemctl --global disable armonix-gui.service >/dev/null 2>&1 || true
+        systemctl --user --global disable armonix-gui.service >/dev/null 2>&1 || true
         if command -v loginctl >/dev/null 2>&1; then
             loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
                 [ -z "$user" ] && continue


### PR DESCRIPTION
## Summary
- ensure armonix-gui.service is enabled and disabled for all users via the user manager

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1748442f88323bc3a006e6be19f80