### PR TITLE
Disable MIDI IO in armonix-gui mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ def _create_state_manager(
     ketron_port_keyword: Optional[str],
     ble_port_keyword: Optional[str],
     keypad_device: Optional[str],
+    enable_midi_io: bool,
     parent_logger: Optional[logging.Logger] = None,
 ) -> StateManager:
     state_logger = (
@@ -101,6 +102,7 @@ def _create_state_manager(
         ketron_port_keyword=ketron_port_keyword,
         ble_port_keyword=ble_port_keyword,
         keypad_device=keypad_device,
+        enable_midi_io=enable_midi_io,
         logger=state_logger,
     )
 
@@ -316,6 +318,7 @@ def _run_headless_mode(
             ketron_port_keyword=ketron_port_keyword,
             ble_port_keyword=ble_port_keyword,
             keypad_device=keypad_device,
+            enable_midi_io=True,
             parent_logger=logger,
         )
 
@@ -375,6 +378,7 @@ def _run_gui_mode(
                     ketron_port_keyword=ketron_port_keyword,
                     ble_port_keyword=ble_port_keyword,
                     keypad_device=keypad_device,
+                    enable_midi_io=False,
                     parent_logger=logger,
                 )
 

--- a/statemanager.py
+++ b/statemanager.py
@@ -22,6 +22,7 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
         ketron_port_keyword="MIDI Gadget",
         ble_port_keyword="Bluetooth",
         keypad_device="/dev/input/by-id/usb-1189_USB_Composite_Device_CD70134330363235-if01-event-kbd",
+        enable_midi_io=True,
         logger=None,
     ):
         super().__init__()
@@ -37,6 +38,7 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
         )
         self.ketron_port_keyword = ketron_port_keyword or "MIDI Gadget"
         self.ble_port_keyword = ble_port_keyword or "Bluetooth"
+        self.midi_io_enabled = enable_midi_io
         self.ledbar = None
         self.master_port = None
         self.ketron_port = None
@@ -115,7 +117,8 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
             self.ble_connected = True
             if self.verbose:
                 self.logger.debug("Dispositivo Bluetooth MIDI trovato: %s", ble_port)
-            self.start_ble_listener()
+            if self.midi_io_enabled:
+                self.start_ble_listener()
         elif not ble_port and self.ble_connected:
             if self.verbose:
                 self.logger.debug("Bluetooth MIDI scollegato")
@@ -244,6 +247,8 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
 
     # -------- Bluetooth MIDI methods --------
     def start_ble_listener(self):
+        if not self.midi_io_enabled:
+            return
         if self.ble_listener_thread and self.ble_listener_thread.is_alive():
             return  # già attivo
         self.ble_listener_stop = threading.Event()
@@ -275,6 +280,8 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
     # -------- DAW MIDI methods --------
     # -------- Master MIDI methods --------
     def start_master_listener(self):
+        if not self.midi_io_enabled:
+            return
         if hasattr(self, "master_listener_thread") and self.master_listener_thread and self.master_listener_thread.is_alive():
             return  # già attivo
         self.master_listener_stop = threading.Event()


### PR DESCRIPTION
## Summary
- allow `_create_state_manager` to control whether MIDI IO should be active
- run the state manager without MIDI IO when armonix-gui launches so it only manages LEDs and VNC
- guard BLE and master listeners so they do not open MIDI ports when MIDI IO is disabled

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17cc05c208323bbbe40d83bed427f