### PR TITLE
Respect headless config in armonix-gui and disable GUI MIDI IO

### DIFF
--- a/launchkey_midi_filter.py
+++ b/launchkey_midi_filter.py
@@ -227,6 +227,9 @@ def _apply_group_colors(outport, section, pid, group_id, mode="static"):
 
 def poll_ports(state_manager):
     """Handle Launchkey-specific port detection and listeners."""
+    if not getattr(state_manager, "midi_io_enabled", True):
+        return
+
     global _daw_connected, _daw_in_port, _daw_out_port
 
     daw_in_port = state_manager.find_port(DAW_IN_PORT_KEYWORD)

--- a/scripts/armonix-gui
+++ b/scripts/armonix-gui
@@ -7,9 +7,28 @@ BASE_DIR = "/usr/lib/armonix"
 if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 
+from configuration import load_config
 from main import main
+
+
+def _extract_config_path(argv):
+    """Return the config path passed via ``--config`` (if any)."""
+
+    for index, arg in enumerate(argv):
+        if arg == "--config" and index + 1 < len(argv):
+            return argv[index + 1]
+        if arg.startswith("--config="):
+            return arg.split("=", 1)[1]
+    return None
 
 
 if __name__ == "__main__":
     os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+    config_path = _extract_config_path(sys.argv[1:])
+    config = load_config(config_path)
+
+    if config.headless:
+        sys.exit(0)
+
     main(["--gui", "--enable-vnc", *sys.argv[1:]])

--- a/statemanager.py
+++ b/statemanager.py
@@ -104,7 +104,8 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
             self.keypad_connected = True
             if self.verbose:
                 self.logger.debug("Tastierino USB collegato")
-            self.start_keypad_listener()
+            if self.midi_io_enabled:
+                self.start_keypad_listener()
         elif not keypad_present and self.keypad_connected:
             self.keypad_connected = False
             if self.verbose:
@@ -215,6 +216,8 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
 
     # -------- Tastierino USB methods --------
     def on_keypad_event(self, scancode, keycode, is_down):
+        if not self.midi_io_enabled:
+            return
         if not self.ketron_port:
             if self.verbose:
                 self.logger.debug("Ricevuto evento da tastierino ma Ketron non collegato.")
@@ -225,6 +228,8 @@ class StateManager(QtCore.QObject if QT_AVAILABLE else object):
             keypad_midi_callback(keycode, is_down, outport, verbose=self.verbose)
 
     def start_keypad_listener(self):
+        if not self.midi_io_enabled:
+            return
         if self.keypad_listener and self.keypad_listener.is_alive():
             return  # già attivo
         self.keypad_stop_event.clear()


### PR DESCRIPTION
## Summary
- stop the armonix-gui launcher early when the configuration is headless
- prevent the GUI StateManager from starting MIDI listeners when MIDI IO is disabled
- guard Launchkey DAW polling when MIDI IO is disabled so only the engine handles MIDI traffic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18454e378832389be06ed3c55c2fb